### PR TITLE
Remove unused shared alias

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,9 +14,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "paths": {
-      "@frontend-templates/shared": ["packages/shared/src/index.ts"]
-    }
+    "paths": {}
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary
- clean up `tsconfig.base.json` by removing the `@frontend-templates/shared` path alias which pointed to a non-existent package

## Testing
- `npm test` *(fails: `nx` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851c03d4414832abc99046d9e5dbf9f